### PR TITLE
Add log_file location option to config.ini for make_detector

### DIFF
--- a/dragonfly/utils/make_densities.py
+++ b/dragonfly/utils/make_densities.py
@@ -35,6 +35,12 @@ def make_dens(config_fname, yes=False, verbose=False):
     '''
     config = read_config.MyConfigParser()
     config.read(config_fname)
+    log_file = config.get_filename('make_densities', 'log_file', fallback='simdata.log')
+
+    logging.basicConfig(filename=log_file, level=logging.INFO,
+                        format='%(asctime)s - %(levelname)s - %(message)s')
+    logging.info('\n\nStarting.... make_densities')
+    logging.info(' '.join(sys.argv))
 
     pdb_code = None
     pdb_file = config.get_filename('make_densities', 'in_pdb_file', fallback=None)
@@ -81,10 +87,6 @@ def main():
                         help='Say yes to all prompts')
     args = parser.parse_args()
 
-    logging.basicConfig(filename='simdata.log', level=logging.INFO,
-                        format='%(asctime)s - %(levelname)s - %(message)s')
-    logging.info('\n\nStarting.... make_densities')
-    logging.info(' '.join(sys.argv))
 
     make_dens(args.config_fname, yes=args.yes, verbose=args.verbose)
 

--- a/dragonfly/utils/make_detector.py
+++ b/dragonfly/utils/make_detector.py
@@ -35,6 +35,15 @@ def make_detector(config_fname, yes=False, verbose=False):
     config = read_config.MyConfigParser()
     config.read(config_fname)
 
+    log_file = config.get_filename('make_detector', 'log_file', fallback='logs/simdata.log')
+
+    logging.basicConfig(filename=log_file, level=logging.INFO,
+                        format='%(asctime)s - %(levelname)s - %(message)s')
+    logging.info('\n\nStarting make_detector....')
+    logging.info(' '.join(sys.argv))
+
+
+
     det_fname = config.get_filename('make_detector', 'out_detector_file')
 
     if not (yes or py_utils.check_to_overwrite(det_fname)):
@@ -81,11 +90,6 @@ def main():
     parser.add_argument('-y', '--yes', action='store_true',
                         help='Say yes to all prompts')
     args = parser.parse_args()
-
-    logging.basicConfig(filename='simdata.log', level=logging.INFO,
-                        format='%(asctime)s - %(levelname)s - %(message)s')
-    logging.info('\n\nStarting make_detector....')
-    logging.info(' '.join(sys.argv))
 
     make_detector(args.config_fname, yes=args.yes, verbose=args.verbose)
 

--- a/dragonfly/utils/make_detector.py
+++ b/dragonfly/utils/make_detector.py
@@ -35,7 +35,7 @@ def make_detector(config_fname, yes=False, verbose=False):
     config = read_config.MyConfigParser()
     config.read(config_fname)
 
-    log_file = config.get_filename('make_detector', 'log_file', fallback='logs/simdata.log')
+    log_file = config.get_filename('make_detector', 'log_file', fallback='simdata.log')
 
     logging.basicConfig(filename=log_file, level=logging.INFO,
                         format='%(asctime)s - %(levelname)s - %(message)s')

--- a/dragonfly/utils/make_intensities.py
+++ b/dragonfly/utils/make_intensities.py
@@ -43,6 +43,15 @@ def make_intens(config_fname, yes=False, verbose=False):
     intens_fname = config.get_filename('make_intensities', 'out_intensity_file')
     num_threads = config.getint('make_intensities', 'num_threads', fallback=4)
 
+    log_file = config.get_filename('make_intensities', 'log_file', fallback='simdata.log')
+
+
+    logging.basicConfig(filename=log_file, level=logging.INFO,
+                        format='%(asctime)s - %(levelname)s - %(message)s')
+    logging.info('\n\nStarting.... make_intensities')
+    logging.info(' '.join(sys.argv))
+
+
     if not (yes or py_utils.check_to_overwrite(intens_fname)):
         return
 
@@ -86,11 +95,6 @@ def main():
     parser.add_argument('-y', '--yes', action='store_true',
                         help='Say yes to all prompts')
     args = parser.parse_args()
-
-    logging.basicConfig(filename='simdata.log', level=logging.INFO,
-                        format='%(asctime)s - %(levelname)s - %(message)s')
-    logging.info('\n\nStarting.... make_intensities')
-    logging.info(' '.join(sys.argv))
 
     make_intens(args.config_fname, yes=args.yes, verbose=args.verbose)
 


### PR DESCRIPTION
The make_detector script will look for a parameter `log_file` in `[make_detector]` in the `config.ini` and use that to save logging info. Defaults to `simdata.log`. Had to move lines 85-89 of `main()` into `make_detector()` so that the config can be read first, then the log is created.

Note: In the previous version, the `simdata.log` file would be created in the current working directory of where the `dragonfly.utils.make_detector` script was made. Now the `log_file` path is relative to the `config.ini`.

 Example for previous version: If I am in directory `x/`,  running `dragonfly.utils.make_detector -c ./recon_0001/config.ini` in the previous version would produce a `simdata.log` file in `x/`. In this version, the log would be created at `./recon_0001/simdata.log`. If the `config.ini` specified:
```
[make_detector]
log_file = logs/simdata.log
```
then the log file would be written to `./recon_0001/logs/simdata.log`.